### PR TITLE
style: modernize ui with accent and 3d effects

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -27,6 +27,8 @@ body {
     font-family: 'Roboto', sans-serif;
     line-height: 1.6;
     -webkit-tap-highlight-color: transparent;
+    background-color: #f8f9fa;
+    color: var(--secondary-color);
 }
 
 .page {
@@ -59,12 +61,14 @@ li {
     font-weight: bold;
     border-radius: 30px;
     text-decoration: none;
-    transition: transform 0.3s ease, background-color 0.3s ease;
+    box-shadow: 4px 4px 0 var(--accent-color-dark);
+    transition: transform 0.3s ease, background-color 0.3s ease, box-shadow 0.3s ease;
 }
 
 .button:hover {
     background-color: var(--accent-color-dark);
-    transform: scale(1.1);
+    transform: translate(-2px, -2px);
+    box-shadow: 6px 6px 0 var(--accent-color-dark);
 }
 
 .border-shadow {

--- a/components/ContentCard.vue
+++ b/components/ContentCard.vue
@@ -20,9 +20,10 @@ const props = defineProps({
 
 <style scoped>
 .card {
-  background-color: white;
+  background-color: var(--primary-color);
+  border: 2px solid var(--accent-color);
   border-radius: 10px;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 6px 6px 0 var(--accent-color);
   padding: 1.5rem;
   margin: 1rem 0;
   transition: transform 0.3s ease, box-shadow 0.3s ease;
@@ -31,7 +32,7 @@ const props = defineProps({
 
 .card:hover {
   transform: translateY(-5px);
-  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: 8px 8px 0 var(--accent-color-dark);
 }
 
 .card-link {
@@ -47,7 +48,12 @@ const props = defineProps({
 h3 {
   margin: 0 0 0.5rem;
   font-size: 1.5rem;
-  color: #333;
+  color: var(--accent-color);
+  transition: color 0.3s ease;
+}
+
+.card:hover h3 {
+  color: var(--accent-color-dark);
 }
 
 p {

--- a/components/layout/Footer.vue
+++ b/components/layout/Footer.vue
@@ -33,9 +33,10 @@ footer {
   display: flex;
   justify-content: center;
   text-align: center;
-  background-color: #1e1e2f;
-  color: white;
+  background: linear-gradient(135deg, var(--accent-color), var(--accent-color-dark));
+  color: var(--primary-color);
   padding: 2rem 0;
+  box-shadow: 0 -4px 0 var(--accent-color-dark);
 }
 
 .footer-content p {
@@ -57,14 +58,14 @@ footer {
 }
 
 .social-links a {
-  color: white;
+  color: var(--primary-color);
   text-decoration: none;
   font-size: 1.1rem;
   transition: color 0.3s ease;
 }
 
 .social-links a:hover {
-  color: var(--accent-color);
+  color: var(--secondary-color);
 }
 
 .pulsating {

--- a/components/layout/Header.vue
+++ b/components/layout/Header.vue
@@ -48,7 +48,8 @@ onClickOutside(target, () => {
 <style scoped>
 /* Header styling */
 header {
-  box-shadow: 0 10px 15px rgba(0, 0, 0, 0.1), 0 4px 6px rgba(0, 0, 0, 0.1);
+  background-color: var(--primary-color);
+  box-shadow: 0 4px 0 var(--accent-color), 0 8px 16px rgba(0, 0, 0, 0.1);
   position: sticky;
   top: 0;
   z-index: 999;
@@ -66,17 +67,18 @@ nav {
 }
 
 nav a {
-  color: black;
+  color: var(--secondary-color);
   text-decoration: none;
   font-weight: bolder;
   padding: 0.5rem 1rem;
   border-bottom: 2px solid transparent;
+  transition: color 0.3s ease, border-bottom 0.3s ease;
 }
 
 /* Hover and focus effects for navigation links */
 nav a:hover {
+  color: var(--accent-color);
   border-bottom: 2px solid var(--accent-color);
-  transition: border-bottom 0.5s ease;
 }
 
 /* Navigation links styling */


### PR DESCRIPTION
## Summary
- refresh page styles with lighter background and accent-colored 3D buttons
- add accent-themed header, footer and content cards for a modern look

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b00c681bb483238cfc73e4c69e1211