### PR TITLE
refactor: switch to pastel palette

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1,8 +1,8 @@
 :root {
     --primary-color: #ffffff;
     --secondary-color: #000000;
-    --accent-color: #c93535;
-    --accent-color-dark: #e73535;
+    --accent-color: #b5e1e3;
+    --accent-color-dark: #89c2d9;
 }
 
 @keyframes pulse {
@@ -61,14 +61,12 @@ li {
     font-weight: bold;
     border-radius: 30px;
     text-decoration: none;
-    box-shadow: 4px 4px 0 var(--accent-color-dark);
-    transition: transform 0.3s ease, background-color 0.3s ease, box-shadow 0.3s ease;
+    transition: transform 0.3s ease, background-color 0.3s ease;
 }
 
 .button:hover {
     background-color: var(--accent-color-dark);
     transform: translate(-2px, -2px);
-    box-shadow: 6px 6px 0 var(--accent-color-dark);
 }
 
 .border-shadow {

--- a/components/BackToTop.vue
+++ b/components/BackToTop.vue
@@ -29,7 +29,6 @@ const scrollToTop = () => {
   border: none;
   border-radius: 50px;
   cursor: pointer;
-  box-shadow: 0 2px 10px var(--accent-color-dark);
   transition: all 0.3s ease;
 }
 

--- a/components/layout/Footer.vue
+++ b/components/layout/Footer.vue
@@ -18,7 +18,7 @@
             target="_blank" rel="noopener noreferrer">CV</a>
         </li>
       </ul>
-      <p class="pulsating">Built with ❤️ using Nuxt 3</p>
+      <p class="pulsating">Built with 🤍 using Nuxt 3</p>
     </div>
   </footer>
 </template>


### PR DESCRIPTION
## Summary
- use pastel accent colors and remove button shadow
- tone down footer heart and lighten overall palette

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b01a163ea883239b2217ce7574540b